### PR TITLE
Fixing flash functionality when no words are selected

### DIFF
--- a/literacywidget.js
+++ b/literacywidget.js
@@ -225,7 +225,7 @@ class LiteracyWidget extends Widget {
                 break;
             case FLASH:
                 lastIncorrectIndex = this._getCheckboxIndex( [ ...this.element.querySelectorAll( '.incorrect-word input[type="checkbox"]' ) ].pop() );
-                this._showCheckboxes( lastIncorrectIndex || 0 );
+                this._showCheckboxes( lastIncorrectIndex ? lastIncorrectIndex !== -1 : 0 );
                 break;
             case FINISH:
                 this._updateWordCounts();


### PR DESCRIPTION
## Description
A minor change made to the `_setState()` method to correct state change for the checkboxes when the interface flashes to yellow.

## Related Issues
closes #36 