### PR TITLE
Fix missing button labels after first submission

### DIFF
--- a/literacywidget.js
+++ b/literacywidget.js
@@ -1,3 +1,4 @@
+import { t } from 'enketo/translator';
 import events from 'enketo-core/src/js/event';
 import Widget from 'enketo-core/src/js/widget';
 const FLASH = 'flash';
@@ -62,9 +63,10 @@ class LiteracyWidget extends Widget {
 
         this.input = this.element.querySelector( `input[name="${name}"]` );
 
+        console.log("derp");
         optionWrapper.prepend(
             fragment.createContextualFragment(
-                `<button class="btn btn-default literacy-widget__start" type="button" data-i18n="literacywidget.start"></button>
+                `<button class="btn btn-default literacy-widget__start" type="button">${t("literacywidget.start")}</button>
                 <div class="literacy-widget__timer"/>`
             )
         );
@@ -72,7 +74,7 @@ class LiteracyWidget extends Widget {
         const startButton = optionWrapper.querySelector( '.literacy-widget__start' );
 
         optionWrapper.append(
-            fragment.createContextualFragment( '<button class="btn btn-primary literacy-widget__stop" disabled type="button" data-i18n="literacywidget.finish"></button>' )
+            fragment.createContextualFragment( `<button class="btn btn-primary literacy-widget__stop" disabled type="button">${t("literacywidget.finish")}</button>` )
         );
         optionWrapper.append( this.resetButtonHtml );
 

--- a/literacywidget.js
+++ b/literacywidget.js
@@ -63,7 +63,6 @@ class LiteracyWidget extends Widget {
 
         this.input = this.element.querySelector( `input[name="${name}"]` );
 
-        console.log("derp");
         optionWrapper.prepend(
             fragment.createContextualFragment(
                 `<button class="btn btn-default literacy-widget__start" type="button">${t("literacywidget.start")}</button>


### PR DESCRIPTION
…by using `t()` instead of `data-i18n`, since:
1. the latter appears to happen only once when the survey is first loaded: https://github.com/enketo/enketo-express/blob/df8057b7588eaafe9fd59bb10fa9401168cd0643/public/js/src/enketo-webform.js#L259-L260
2. built-in widgets (e.g. the file picker) use `t()`, not `data-i18n`: https://github.com/enketo/enketo-core/blob/f37eed223140f7bee2700af2b1b7277ceee71fe8/src/widget/file/filepicker.js#L3