### PR TITLE
Bump enketo-core version to 9.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "private": true,
     "license": "Apache-2.0",
     "dependencies": {
-        "enketo-core": "8.3.0"
+        "enketo-core": "9.0.1"
     }
 }


### PR DESCRIPTION
This PR bumps up enketo-core version to 9.0.1 to pair up with https://github.com/kobotoolbox/enketo-express-extra-widgets/pull/9 which bumps Enketo express version to 7.5.1

Version of this repo needs to be bumped because node 22 is used in Enketo express 7.5.1 and the currently used Enketo version expects node version being from 18 to 21.